### PR TITLE
Add explicit conda activation to installation steps for clarity and reliability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To install `simplefold` package from github repository, run
 git clone https://github.com/apple/ml-simplefold.git
 cd ml-simplefold
 conda create -n simplefold python=3.10
+conda activate simplefold
 python -m pip install -U pip build; pip install -e .
 ```
 If you want to use MLX backend on Apple silicon: 


### PR DESCRIPTION
This ensures the correct Python environment is used for pip installs. Might be helpful for beginners.