### PR TITLE
Match Python version requirement of >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "simplefold"
 version = "0.1.0"
 description = "Folding proteins with SimpleFold."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [
     { name = "Yuyang Wang", email = "yuyangw@apple.com" },


### PR DESCRIPTION
Match the README and the package requirement.

Without this change, installing with `uv` (for example) fails with the inability to resolve packages that require python3.10 and above.