### PR TITLE
Remove inference multiplicity

### DIFF
--- a/configs/experiment/test.yaml
+++ b/configs/experiment/test.yaml
@@ -25,6 +25,3 @@ model:
     tau: 0.01
     log_timesteps: True
     w_cutoff: 0.99
-
-  processor:
-    inference_multiplicity: 1

--- a/src/simplefold/processor/protein_processor.py
+++ b/src/simplefold/processor/protein_processor.py
@@ -26,7 +26,6 @@ class ProteinDataProcessor:
         scale=16.0, 
         ref_scale=5.0, 
         multiplicity=1,
-        inference_multiplicity=1,
         backend="torch",
     ):
         self.device = device
@@ -34,7 +33,6 @@ class ProteinDataProcessor:
         self.ref_scale = ref_scale
         # if multiplicity > 1, effective batch size is multiplicity * batch_size
         self.multiplicity = multiplicity
-        self.inference_multiplicity = inference_multiplicity
         self.backend = backend
         if self.backend == "mlx":
             self.center_random_fn = mlx_center_random
@@ -69,7 +67,7 @@ class ProteinDataProcessor:
 
         esmaa = af2_idx_to_esm_idx(aatype, mask, af2_to_esm)
 
-        multiplicity = self.multiplicity if not inference else self.inference_multiplicity
+        multiplicity = self.multiplicity if not inference else 1
 
         esm_s_, _ = compute_language_model_representations(
             esmaa, esm_model, esm_dict, backend=self.backend
@@ -167,7 +165,7 @@ class ProteinDataProcessor:
             batch_size, -1)
         batch['mol_index'] = mol_index
 
-        batch = self.batch_to_device(batch, multiplicity=self.inference_multiplicity)
+        batch = self.batch_to_device(batch)
 
         if esm_model is not None and batch.get('esm_s', None) is None:
             print("Processing ESM features for inference...")


### PR DESCRIPTION
Closes #24 

### Description

Running inference with `--nsamples_per_protein` greater than 1 blows up memory using the torch backend. This happens because `inference_multiplicity` was used to replicate every tensor (including ESM embeddings) `nsample_per_protein` times before moving them to the GPU, so multi-sample inference pushed huge duplicated feature tensors into vRAM and regularly OOM’d.

After this fix, taking 5 samples of a protein sequence of ~1000 amino acids stays in around 31GiB of vRAM using the torch backend (instead of running OOM for a 81GiB GPU.)

### Implementation

I fixed it by removing `inference_multiplicity` altogether to simply run inference in a `nsample_per_protein` loop.

This does slow down inference since it's not batched, so feel free to close the PR, just here for future reference.